### PR TITLE
Add updateWinsAndLosses

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -32,17 +32,17 @@ class App extends Component<IProps, IState> {
   //     .then(data => this.setState({ characters: data }));
   // }
 
-  // updateWinsAndLosses = (character: CleanedCharacter, isWin: boolean) => {
-  //   if (isWin) {
-  //     character.wins += 1
-  //   } else {
-  //     character.losses += 1
-  //   }
-  //   let foundTier = Math.floor(((character.wins / (character.wins + character.losses)) * 5));
-  //   foundTier = foundTier < 1 ? 1 : foundTier;
-  //   character.tier = foundTier;
-  //   this.setState({ characters: [...this.state.characters] });
-  // }
+  updateWinsAndLosses = (character: CleanedCharacter, isWin: boolean) => {
+    if (isWin) {
+      character.wins += 1
+    } else {
+      character.losses += 1
+    }
+    let foundTier = Math.floor(((character.wins / (character.wins + character.losses)) * 5));
+    foundTier = foundTier < 1 ? 1 : foundTier;
+    character.tier = foundTier;
+    this.setState({ characters: [...this.state.characters] });
+  }
 
   // toggleMained = (character: CleanedCharacter) => {
 	// 	character.isMained = !character.isMained;


### PR DESCRIPTION
### This PRs additions:
* Adds method `updateWinsAndLosses` which updates a characters wins or losses, updates their tier accordingly, and sets it to state. 
* Passes `updateWinsAndLosses` into CharacterCard.
 
### Reviewer starting point: 
src/App/App.tsx
 
### How to manually test:  
* npm start
* Click a `+` button on a CharacterCard and view that their tier rank changes.
 
### background context:  
N/A
 
### Relevant tickets: 
Closes #31 
 
### Screenshots:

 
### Questions: 
