### PR TITLE
Balance foundTier logic to be more generous

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -52,8 +52,8 @@ class App extends Component<IProps, IState> {
     } else {
       character.losses += 1
     }
-    let foundTier = Math.floor(((character.wins / (character.wins + character.losses)) * 5));
-    foundTier = foundTier < 1 ? 1 : foundTier;
+    let foundTier = Math.floor(((character.wins / (character.wins + character.losses)) * 6));
+    foundTier = foundTier < 1 ? 1 : foundTier > 5 ? 5 : foundTier;
     character.tier = foundTier;
     this.setState({ characters: [...this.state.characters] });
     localStorage.setItem('characters', JSON.stringify(this.state.characters));


### PR DESCRIPTION
### This PRs additions:
* Balances foundTier math to get a more generous tier rank result
* Tiers by percentages:
    * A+: 83.3 and above 
    * A: 66.6-83.2
    * B: 50.0-66.5
    * C: 33.3-49.9
    * F: 33.2 and under
 
### Reviewer starting point: 
src/App/App.tsx
 
### How to manually test:  
* npm start
* Add wins and losses for a character and see the new logic for award tier ranks 
 
### background context:  
This could still be tweaked to give A+ at a lower percent. 75% maybe?
 
### Relevant tickets: 
Closes #97 
 
### Screenshots:
N/A
 
### Questions: 
N/A