### PR TITLE
Fix bug where echo characters were at bottom of character list

### DIFF
--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -30,10 +30,7 @@ export const getCharacters = () => {
       const fetchedCharacters = data.data.fetchCharacters.map((character: FetchedCharacter) => {
         return cleanFetchedCharacter(character)
       })
-      return fetchedCharacters.sort((a: CleanedCharacter, b: CleanedCharacter) => {
-        console.log(`string: ${a.order}, number ${+a.order}`)
-        return parseInt(a.order, 16) - parseInt(b.order, 16)
-      });
+      return fetchedCharacters.reverse()
     })
     .catch(error => console.error(error))
   )


### PR DESCRIPTION
### This PRs additions:
Fixes bug where echo characters were at bottom of character list
 
### Reviewer starting point: 
`ApiCalls.ts`
 
### How to manually test:  
Check that echo characters such as "Daisy" are not at the bottom of the list, and are instead in the right order (next to "Peach", towards the top-middle of the list).
 
### background context:  

 
### Relevant tickets: 
Closes #111 
 
### Screenshots:
N/A
 
### Questions: 
N/A