### PR TITLE
Fix getCharacters type to return Promise<[CleanedCharacter]>

### DIFF
--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -1,6 +1,6 @@
 import { FetchedCharacter, CleanedCharacter, cleanFetchedCharacter } from './utils/utils';
 
-export const getCharacters = () => {
+export const getCharacters: () => Promise<[CleanedCharacter]> = () => {
   return (
     fetch('https://my-tier-ultimate-api.herokuapp.com/graphql', {
       method: 'POST',


### PR DESCRIPTION
### This PRs additions:
* Adds a fix for dev server console warning: `'CleanedCharacter' is defined but never used`
* The solution was to refactor `getCharacters` type to expect a return value of `Promise<[CleanedCharacter]>`
 
### Reviewer starting point: 
`src/apiCalls.ts`
 
### How to manually test:  
Run `npm start` and notice that there are no warnings in the console
 
### background context:  
Previously a warning was being thrown in the console when starting the development server:
```
Compiled with warnings.

src/apiCalls.ts
  Line 1:28:  'CleanedCharacter' is defined but never used  @typescript-eslint/no-unused-vars
```
 
### Relevant tickets: 
Closes #114 
 
### Screenshots:
N/A
 
### Questions: 
N/A